### PR TITLE
async storage set on signup or login, cleared with logout button

### DIFF
--- a/components/redux/actions/authActions.js
+++ b/components/redux/actions/authActions.js
@@ -49,7 +49,6 @@ export const auth = (email, password) => async dispatch => {
       })
     })
     const resData = await res.json();
-    console.log('resData',resData);
     dispatch(getUser(resData));
     }catch (authError) {
     return dispatch(getUser({error: authError}))

--- a/components/screens/authLoading.js
+++ b/components/screens/authLoading.js
@@ -1,33 +1,28 @@
-import React from 'react';
-import {
-  ActivityIndicator,
-  AsyncStorage,
-  StatusBar,
-  StyleSheet,
-  View,
-} from 'react-native';
+import React from 'react'
+import { View } from 'react-native'
+import { loadUser } from '../storage/userStorage'
 
-class AuthLoadingScreen extends React.Component {
+class AuthLoading extends React.Component {
   componentDidMount() {
-    this._bootstrapAsync();
+    this.checkId()
   }
 
-  // Fetch the token from storage then navigate to our appropriate place
-  _bootstrapAsync = async () => {
-    const userToken = await AsyncStorage.getItem('userToken');
+  checkId = async () => {
+    const user = await loadUser()
 
-    // This will switch to the App screen or Auth screen and this loading
-    // screen will be unmounted and thrown away.
-    this.props.navigation.navigate(userToken ? 'App' : 'Auth');
-  };
+    if (user.id !== null) {
+      this.props.navigation.navigate('App')
+    }
+    this.props.navigation.navigate('Login')
+  }
 
-  // Render any loading content that you like here
   render() {
     return (
       <View>
-        <ActivityIndicator />
-        <StatusBar barStyle="default" />
+        <h1>{'why'}</h1>
       </View>
-    );
+    )
   }
 }
+
+export default AuthLoading

--- a/components/screens/home.js
+++ b/components/screens/home.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Text,ImageBackground ,TouchableOpacity} from 'react-native';
+import {View, Text,ImageBackground ,TouchableOpacity, AsyncStorage} from 'react-native';
 import styles from '../../assets/styles/homeStyles'
 
 export default class HomePage extends React.Component{
@@ -35,8 +35,16 @@ export default class HomePage extends React.Component{
                           <Text style={styles.text}>Users List</Text>
                       </TouchableOpacity>
                       </View>
+                      <View style={styles.journals}>
+                      <TouchableOpacity onPress={async () => {
+                          await AsyncStorage.clear()
+                          this.props.navigation.navigate('Login')
+                      }}>
+                          <Text style={styles.text}>Logout</Text>
+                      </TouchableOpacity>
+                      </View>
                   </View>
-            
+
               </ImageBackground>
 
           )

--- a/components/screens/loginForm.js
+++ b/components/screens/loginForm.js
@@ -1,12 +1,11 @@
 import React, { Component } from "react";
-import { View, Text, TextInput, ImageBackground, KeyboardAvoidingView, ScrollView, TouchableOpacity, Button } from "react-native";
+import { View, Text, TextInput, ImageBackground, KeyboardAvoidingView, ScrollView, TouchableOpacity, Button, AsyncStorage } from "react-native";
 import styles from '../../assets/styles/loginStyles'
 import RoundedButton from "../buttons/RoundedButton";
 import authReducer from '../redux/actions/authActions'
 import {auth} from '../redux/actions/authActions'
 import {connect} from 'react-redux'
 import {loadUser, saveUser} from '../storage/userStorage'
-
 
 class Login extends Component {
     constructor(){
@@ -21,20 +20,18 @@ class Login extends Component {
 
     componentDidMount= async () => {
       let user = await loadUser()
-      console.log("USER", user)
+      console.log("USER", user.id)
     }
 
     async logIn() {
-      console.log('Pressed login')
       await this.props.userAuth(this.state.email, this.state.password)
-      console.log(this.props)
         if (this.props.user.email=== this.state.email) {
-          saveUser(this.state)
+          saveUser(this.props.user)
           this.props.navigation.navigate('Home')
         } else {
             this.toggleMessage()
         }
-      } 
+      }
 
      toggleMessage() {
        this.setState({
@@ -65,10 +62,10 @@ class Login extends Component {
                     placeholderTextColor = 'white'
                     secureTextEntry
                 />
-                <RoundedButton text="Login" color = "white" backgroundColor= '#FFA611' 
+                <RoundedButton text="Login" color = "white" backgroundColor= '#FFA611'
                 onPress={this.logIn}/>
-               
-                <RoundedButton text="Create Account" color = "white" backgroundColor= '#FFA611' 
+
+                <RoundedButton text="Create Account" color = "white" backgroundColor= '#FFA611'
                 onPress={()=>this.props.navigation.navigate('Signup')}/>
 
           </ScrollView>
@@ -88,5 +85,5 @@ class Login extends Component {
       })
 
       export default connect(mapState,mapDispatch)(Login)
-      
+
 

--- a/components/screens/navigators.js
+++ b/components/screens/navigators.js
@@ -12,6 +12,7 @@ import UsersList from './usersList'
 import Login from './loginForm'
 import Signup from './signUpForm'
 import Icon from "react-native-vector-icons/Ionicons"
+import AuthLoading from './authLoading'
 
 export const authNavigator = createStackNavigator({
     Login: {screen: Login},
@@ -63,15 +64,17 @@ export const BottomTabNavigator = createBottomTabNavigator({
       activeTintColor:  '#636b61',
       inactiveTintColor: '#636b61',
     },
-  })})
+  })}
+  )
  const MainNavigator = createAppContainer(BottomTabNavigator)
   export const SwitchNavigator = createSwitchNavigator(
     {
+      AuthLoading: AuthLoading,
       Login: authNavigator,
       App: BottomTabNavigator
     },
     {
-      initialRouteName: 'Login'
+      initialRouteName: 'AuthLoading'
     }
   );
 


### PR DESCRIPTION
This works in the expo demo screen, but not on a phone. Also, we should remove the navigation bar from the login/signup screen. 